### PR TITLE
Update _reset()

### DIFF
--- a/adafruit_ltr390.py
+++ b/adafruit_ltr390.py
@@ -307,13 +307,13 @@ class LTR390:  # pylint:disable=too-many-instance-attributes
         # The LTR390 software reset is ill behaved and can leave I2C bus in bad state.
         # Instead, just manually set register reset values per datasheet.
         with self.i2c_device as i2c:
-            i2c.write(bytes([_CTRL, 0x00]))
-            i2c.write(bytes([_MEAS_RATE, 0x22]))
-            i2c.write(bytes([_GAIN, 0x01]))
-            i2c.write(bytes([_INT_CFG, 0x10]))
-            i2c.write(bytes([_INT_PST, 0x00]))
-            i2c.write(bytes([_THRESH_UP, 0xFF, 0xFF, 0x0F]))
-            i2c.write(bytes([_THRESH_LOW, 0x00, 0x00, 0x00]))
+            i2c.write(bytes((_CTRL, 0x00)))
+            i2c.write(bytes((_MEAS_RATE, 0x22)))
+            i2c.write(bytes((_GAIN, 0x01)))
+            i2c.write(bytes((_INT_CFG, 0x10)))
+            i2c.write(bytes((_INT_PST, 0x00)))
+            i2c.write(bytes((_THRESH_UP, 0xFF, 0xFF, 0x0F)))
+            i2c.write(bytes((_THRESH_LOW, 0x00, 0x00, 0x00)))
 
     @property
     def _mode(self):


### PR DESCRIPTION
Potential fix for #11.

Tried various ways to "reset" the I2C bus, but none were successful. So did something simple instead. This PR is not an elegant solution, but does resolve issue.

```python
Adafruit CircuitPython 7.0.0 on 2021-09-20; Adafruit Feather RP2040 with rp2040
>>> import board
>>> import adafruit_ltr390
>>> ltr = adafruit_ltr390.LTR390(board.I2C())
>>> ltr.light
631
>>> ltr.light
7
>>> 
```